### PR TITLE
TypeError: a bytes-like object is required, not 'str' SOLVE

### DIFF
--- a/cloudfrunt.py
+++ b/cloudfrunt.py
@@ -145,7 +145,7 @@ def find_cf_issues(domains):
         try:
             response = urlopen('http://' + domain)
         except HTTPError as e:
-            if e.code == 403 and 'Bad request' in e.fp.read():
+            if e.code == 403 and b'Bad request' in e.fp.read():
                 try:
                     response = urlopen('https://' + domain)
                 except URLError as e:


### PR DESCRIPTION
This solves this error : https://stackoverflow.com/questions/33054527/typeerror-a-bytes-like-object-is-required-not-str-when-writing-to-a-file-in

Adding  a b in 'Bad Request' solved this issue